### PR TITLE
Add `gc` performance entry

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -599,6 +599,26 @@ bare_performance_exports(js_env_t *env, js_value_t *exports) {
   V("disableGarbageCollectionTracking", bare_performance_disable_garbage_collection_tracking, NULL, NULL);
 #undef V
 
+  js_value_t *constants;
+  err = js_create_object(env, &constants);
+  assert(err == 0);
+
+  err = js_set_named_property(env, exports, "constants", constants);
+  assert(err == 0);
+
+#define V(name, n) \
+  { \
+    js_value_t *val; \
+    err = js_create_uint32(env, n, &val); \
+    assert(err == 0); \
+    err = js_set_named_property(env, constants, name, val); \
+    assert(err == 0); \
+  }
+
+  V("MARK_COMPACT", js_garbage_collection_type_mark_compact)
+  V("GENERATIONAL", js_garbage_collection_type_generational)
+#undef V
+
   return exports;
 }
 

--- a/binding.c
+++ b/binding.c
@@ -11,6 +11,28 @@ typedef struct {
   struct hdr_histogram *histogram;
 } bare_performance_histogram_t;
 
+typedef struct {
+  js_ref_t *ctx;
+
+  js_garbage_collection_type_t kind;
+  uint64_t start_time;
+  uint64_t duration;
+} bare_performance_garbage_collection_entry_t;
+
+typedef struct {
+  js_garbage_collection_tracking_t garbage_collection_tracking;
+
+  struct {
+    uint64_t mark_compact;
+    uint64_t generational;
+  } start_time_per_type;
+
+  js_threadsafe_function_t *on_new_entry;
+
+  js_env_t *env;
+  js_ref_t *ctx;
+} bare_performance_garbage_collection_tracking_t;
+
 static js_value_t *
 bare_performance_now(js_env_t *env, js_callback_info_t *info) {
   int err;
@@ -371,6 +393,135 @@ bare_performance_histogram_reset(js_env_t *env, js_callback_info_t *info) {
   return NULL;
 }
 
+static void
+bare_performance_garbage_collection_tracking__on_new_entry(js_env_t *env, js_value_t *on_new_entry, void *context, void *data) {
+  int err;
+
+  bare_performance_garbage_collection_entry_t *entry = (bare_performance_garbage_collection_entry_t *) data;
+
+  js_value_t *ctx;
+  err = js_get_reference_value(env, entry->ctx, &ctx);
+  assert(err == 0);
+
+  js_value_t *args[3];
+
+  err = js_create_double(env, entry->start_time / 1e6, &args[0]);
+  assert(err == 0);
+
+  err = js_create_double(env, entry->duration / 1e6, &args[1]);
+  assert(err == 0);
+
+  err = js_create_int32(env, entry->kind, &args[2]);
+  assert(err == 0);
+
+  free(entry);
+
+  err = js_call_function(env, ctx, on_new_entry, 3, args, NULL);
+  assert(err == 0);
+}
+
+static void
+bare_performance_garbage_collection_tracking__on_end(js_garbage_collection_type_t type, void *data) {
+  int err;
+
+  uint64_t current_timestamp = uv_hrtime();
+
+  bare_performance_garbage_collection_tracking_t *gc = (bare_performance_garbage_collection_tracking_t *) data;
+
+  uint64_t start_time;
+  if (type == js_garbage_collection_type_mark_compact) start_time = gc->start_time_per_type.mark_compact;
+  else start_time = gc->start_time_per_type.generational;
+
+  uint64_t duration = current_timestamp - start_time;
+
+  bare_performance_garbage_collection_entry_t *entry = malloc(sizeof(bare_performance_garbage_collection_entry_t));
+
+  entry->ctx = gc->ctx;
+  entry->start_time = start_time;
+  entry->duration = duration;
+  entry->kind = type;
+
+  err = js_call_threadsafe_function(gc->on_new_entry, entry, js_threadsafe_function_nonblocking);
+  assert(err == 0);
+}
+
+static void
+bare_performance_garbage_collection_tracking__on_start(js_garbage_collection_type_t type, void *data) {
+  int err;
+
+  uint64_t current_timestamp = uv_hrtime();
+
+  bare_performance_garbage_collection_tracking_t *gc = (bare_performance_garbage_collection_tracking_t *) data;
+
+  if (type == js_garbage_collection_type_mark_compact) gc->start_time_per_type.mark_compact = current_timestamp;
+  else gc->start_time_per_type.generational = current_timestamp;
+}
+
+static js_value_t *
+bare_performance_disable_garbage_collection_tracking(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 1;
+  js_value_t *argv[1];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 1);
+
+  bare_performance_garbage_collection_tracking_t *gc;
+  err = js_get_arraybuffer_info(env, argv[0], (void **) &gc, NULL);
+  assert(err == 0);
+
+  err = js_disable_garbage_collection_tracking(env, &gc->garbage_collection_tracking);
+  assert(err == 0);
+
+  err = js_release_threadsafe_function(gc->on_new_entry, js_threadsafe_function_release);
+  assert(err == 0);
+
+  err = js_delete_reference(env, gc->ctx);
+  assert(err == 0);
+
+  return NULL;
+}
+
+static js_value_t *
+bare_performance_enable_garbage_collection_tracking(js_env_t *env, js_callback_info_t *info) {
+  int err;
+
+  size_t argc = 2;
+  js_value_t *argv[2];
+
+  err = js_get_callback_info(env, info, &argc, argv, NULL, NULL);
+  assert(err == 0);
+
+  assert(argc == 2);
+
+  js_value_t *handle;
+
+  bare_performance_garbage_collection_tracking_t *gc;
+  err = js_create_arraybuffer(env, sizeof(bare_performance_garbage_collection_tracking_t), (void **) &gc, &handle);
+  assert(err == 0);
+
+  gc->env = env;
+  gc->garbage_collection_tracking.start_cb = bare_performance_garbage_collection_tracking__on_start;
+  gc->garbage_collection_tracking.end_cb = bare_performance_garbage_collection_tracking__on_end;
+
+  err = js_create_reference(env, argv[0], 1, &gc->ctx);
+  assert(err == 0);
+
+  err = js_create_threadsafe_function(env, argv[1], 64, 1, NULL, NULL, NULL, bare_performance_garbage_collection_tracking__on_new_entry, &gc->on_new_entry);
+  assert(err == 0);
+
+  err = js_unref_threadsafe_function(env, gc->on_new_entry);
+  assert(err == 0);
+
+  err = js_enable_garbage_collection_tracking(env, &gc->garbage_collection_tracking, (void *) gc);
+  assert(err == 0);
+
+  return handle;
+}
+
 static js_value_t *
 bare_performance_exports(js_env_t *env, js_value_t *exports) {
   int err;
@@ -443,6 +594,9 @@ bare_performance_exports(js_env_t *env, js_value_t *exports) {
   V("histogramRecord", bare_performance_histogram_record, NULL, NULL);
   V("histogramAdd", bare_performance_histogram_add, NULL, NULL);
   V("histogramReset", bare_performance_histogram_reset, NULL, NULL);
+
+  V("enableGarbageCollectionTracking", bare_performance_enable_garbage_collection_tracking, NULL, NULL);
+  V("disableGarbageCollectionTracking", bare_performance_disable_garbage_collection_tracking, NULL, NULL);
 #undef V
 
   return exports;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { now, timeOrigin } = require('./lib/hr-time')
 const {
   PerformanceEntry,
+  PerformanceGcEntry,
   PerformanceMark,
   PerformanceMeasure,
   PerformanceObserverEntryList,
@@ -65,6 +66,11 @@ class PerformanceNodeTiming {
 exports.nodeTiming = new PerformanceNodeTiming()
 
 exports.PerformanceEntry = PerformanceEntry
+
+exports.PerformanceGcEntry = PerformanceGcEntry
+
+// For Node.js compatibility
+exports.PerformanceNodeEntry = PerformanceGcEntry
 
 exports.PerformanceMark = PerformanceMark
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const { now, timeOrigin } = require('./lib/hr-time')
 const {
   PerformanceEntry,
-  PerformanceGcEntry,
   PerformanceMark,
   PerformanceMeasure,
   PerformanceObserverEntryList,
@@ -66,9 +65,6 @@ class PerformanceNodeTiming {
 exports.nodeTiming = new PerformanceNodeTiming()
 
 exports.PerformanceEntry = PerformanceEntry
-
-// For Node.js compatibility
-exports.PerformanceNodeEntry = PerformanceGcEntry
 
 exports.PerformanceMark = PerformanceMark
 

--- a/index.js
+++ b/index.js
@@ -101,3 +101,11 @@ exports.createHistogram = function createHistogram(opts) {
 exports.monitorEventLoopDelay = function monitorEventLoopDelay(opts) {
   return new IntervalHistogram(opts)
 }
+
+// For Node.js compatibility
+exports.constants = {
+  NODE_PERFORMANCE_GC_MAJOR: binding.constants.MARK_COMPACT,
+  NODE_PERFORMANCE_GC_MINOR: binding.constants.GENERATIONAL,
+  NODE_PERFORMANCE_GC_INCREMENTAL: -1,
+  NODE_PERFORMANCE_GC_WEAKCB: -1
+}

--- a/index.js
+++ b/index.js
@@ -67,8 +67,6 @@ exports.nodeTiming = new PerformanceNodeTiming()
 
 exports.PerformanceEntry = PerformanceEntry
 
-exports.PerformanceGcEntry = PerformanceGcEntry
-
 // For Node.js compatibility
 exports.PerformanceNodeEntry = PerformanceGcEntry
 

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,3 +1,4 @@
+const binding = require('../binding')
 const { now } = require('./hr-time')
 const { observerType } = require('./constants')
 const { InvalidModificationError } = require('./errors')
@@ -30,6 +31,47 @@ exports.PerformanceEntry = class PerformanceEntry {
 
   get duration() {
     return this._duration
+  }
+}
+
+exports.PerformanceGcEntry = class PerformanceGcEntry extends exports.PerformanceEntry {
+  static _handle = null
+  static _observerCounter = 0
+
+  static _incrementObserverCount() {
+    if (++PerformanceGcEntry._observerCounter === 1) {
+      PerformanceGcEntry._handle = binding.enableGarbageCollectionTracking(
+        this,
+        PerformanceGcEntry._onNewEntry
+      )
+    }
+  }
+
+  static _decrementObserverCount() {
+    if (--PerformanceGcEntry._observerCounter === 0) {
+      binding.disableGarbageCollectionTracking(this._handle)
+      PerformanceGcEntry._handle = null
+    }
+  }
+
+  static _onNewEntry(startTime, duration, kind) {
+    startTime -= TIME_ORIGIN
+
+    const entry = new PerformanceGcEntry(startTime, duration, kind)
+
+    processEntry(entry)
+
+    globalBuffer.push(entry)
+  }
+
+  constructor(startTime, duration, kind) {
+    super('gc', 'gc', startTime, duration)
+
+    this._detail = { kind }
+  }
+
+  get detail() {
+    return this._detail
   }
 }
 
@@ -88,7 +130,7 @@ exports.PerformanceObserver = class PerformanceObserver {
   }
 
   static get supportedEntryTypes() {
-    return ['mark', 'measure']
+    return ['mark', 'measure', 'gc']
   }
 
   observe(opts = {}) {
@@ -134,6 +176,8 @@ exports.PerformanceObserver = class PerformanceObserver {
 
     if (this._entryTypes.size > 0) {
       globalObservers.add(this)
+
+      if (this._entryTypes.has('gc')) exports.PerformanceGcEntry._incrementObserverCount()
     } else {
       this.disconnect()
     }
@@ -147,7 +191,10 @@ exports.PerformanceObserver = class PerformanceObserver {
 
   disconnect() {
     globalObservers.delete(this)
+
+    if (this._entryTypes.has('gc')) exports.PerformanceGcEntry._decrementObserverCount()
     this._entryTypes.clear()
+
     this._type = observerType.UNDEFINED
   }
 }

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,5 +1,5 @@
 const binding = require('../binding')
-const { now } = require('./hr-time')
+const { now, timeOrigin } = require('./hr-time')
 const { observerType } = require('./constants')
 const { InvalidModificationError } = require('./errors')
 
@@ -55,13 +55,11 @@ exports.PerformanceGcEntry = class PerformanceGcEntry extends exports.Performanc
   }
 
   static _onNewEntry(startTime, duration, kind) {
-    startTime -= TIME_ORIGIN
+    startTime -= timeOrigin
 
     const entry = new PerformanceGcEntry(startTime, duration, kind)
 
     processEntry(entry)
-
-    globalBuffer.push(entry)
   }
 
   constructor(startTime, duration, kind) {
@@ -193,6 +191,7 @@ exports.PerformanceObserver = class PerformanceObserver {
     globalObservers.delete(this)
 
     if (this._entryTypes.has('gc')) exports.PerformanceGcEntry._decrementObserverCount()
+
     this._entryTypes.clear()
 
     this._type = observerType.UNDEFINED

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -3,7 +3,6 @@ const { now, timeOrigin } = require('./hr-time')
 const { observerType } = require('./constants')
 const { InvalidModificationError } = require('./errors')
 
-// globals
 const globalObservers = new Set()
 const globalPendingObservers = new Set()
 let globalBuffer = []
@@ -34,30 +33,27 @@ exports.PerformanceEntry = class PerformanceEntry {
   }
 }
 
-exports.PerformanceGcEntry = class PerformanceGcEntry extends exports.PerformanceEntry {
+class PerformanceGCEntry extends exports.PerformanceEntry {
   static _handle = null
-  static _observerCounter = 0
+  static _refs = 0
 
-  static _incrementObserverCount() {
-    if (++PerformanceGcEntry._observerCounter === 1) {
-      PerformanceGcEntry._handle = binding.enableGarbageCollectionTracking(
-        this,
-        PerformanceGcEntry._onNewEntry
-      )
+  static _ref() {
+    if (this._refs++ === 0) {
+      this._handle = binding.enableGarbageCollectionTracking(this, this._onentry)
     }
   }
 
-  static _decrementObserverCount() {
-    if (--PerformanceGcEntry._observerCounter === 0) {
+  static _unref() {
+    if (--this._refs === 0) {
       binding.disableGarbageCollectionTracking(this._handle)
-      PerformanceGcEntry._handle = null
+      this._handle = null
     }
   }
 
-  static _onNewEntry(startTime, duration, kind) {
+  static _onentry(startTime, duration, kind) {
     startTime -= timeOrigin
 
-    const entry = new PerformanceGcEntry(startTime, duration, kind)
+    const entry = new PerformanceGCEntry(startTime, duration, kind)
 
     processEntry(entry)
   }
@@ -175,7 +171,7 @@ exports.PerformanceObserver = class PerformanceObserver {
     if (this._entryTypes.size > 0) {
       globalObservers.add(this)
 
-      if (this._entryTypes.has('gc')) exports.PerformanceGcEntry._incrementObserverCount()
+      if (this._entryTypes.has('gc')) PerformanceGCEntry._ref()
     } else {
       this.disconnect()
     }
@@ -190,7 +186,7 @@ exports.PerformanceObserver = class PerformanceObserver {
   disconnect() {
     globalObservers.delete(this)
 
-    if (this._entryTypes.has('gc')) exports.PerformanceGcEntry._decrementObserverCount()
+    if (this._entryTypes.has('gc')) PerformanceGCEntry._unref()
 
     this._entryTypes.clear()
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "url": "https://github.com/holepunchto/bare-performance/issues"
   },
   "homepage": "https://github.com/holepunchto/bare-performance#readme",
+  "engines": {
+    "bare": ">=1.27.0"
+  },
   "devDependencies": {
     "brittle": "^3.13.1",
     "cmake-bare": "^1.5.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "addon": true,
   "scripts": {
-    "test": "prettier . --check && bare test.js"
+    "test": "prettier . --check && bare --expose-gc test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -321,3 +321,7 @@ test('monitorEventLoopDelay', (t) => {
     t.ok(histogram.count > 0)
   }, 100)
 })
+
+test('constants', (t) => {
+  t.ok(performance.constants)
+})

--- a/test.js
+++ b/test.js
@@ -148,10 +148,9 @@ test('observe - error handling', (t) => {
 })
 
 test('observe - gc', (t) => {
-  // t.plan(5)
+  t.plan(6)
 
   const obs = new performance.PerformanceObserver((list, observer) => {
-    /*
     const entries = list.getEntries()
 
     t.is(entries[0].name, 'gc')
@@ -160,13 +159,14 @@ test('observe - gc', (t) => {
     t.ok(entries[0].duration > 0)
     t.ok(entries[0].detail.kind)
 
+    t.ok(performance.getEntries().length === 0)
+
     observer.disconnect()
-    */
   })
 
   obs.observe({ type: 'gc' })
 
-  t.pass()
+  global.gc()
 })
 
 test('measure', (t) => {

--- a/test.js
+++ b/test.js
@@ -147,6 +147,28 @@ test('observe - error handling', (t) => {
   }
 })
 
+test('observe - gc', (t) => {
+  // t.plan(5)
+
+  const obs = new performance.PerformanceObserver((list, observer) => {
+    /*
+    const entries = list.getEntries()
+
+    t.is(entries[0].name, 'gc')
+    t.is(entries[0].entryType, 'gc')
+    t.ok(entries[0].startTime > 0)
+    t.ok(entries[0].duration > 0)
+    t.ok(entries[0].detail.kind)
+
+    observer.disconnect()
+    */
+  })
+
+  obs.observe({ type: 'gc' })
+
+  t.pass()
+})
+
 test('measure', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
Depends on: https://github.com/holepunchto/libjs/pull/25

---

~(For some reason, it's possible to test the `'observe - gc'` case by setting the test as `solo` on my end. I hope that a `global.gc()` statement can make the test work deterministically.)~