### PR TITLE
Add `encodedBodySize` getter

### DIFF
--- a/lib/timing.js
+++ b/lib/timing.js
@@ -82,6 +82,10 @@ exports.PerformanceResourceTiming = class PerformanceResourceTiming extends (
   get responseStatus() {
     return this._responseStatus
   }
+
+  get encodedBodySize() {
+    return this._resourceInfo.encodedSize
+  }
 }
 
 class PerformanceGCEntry extends exports.PerformanceEntry {


### PR DESCRIPTION
It's already being used by `PerformanceResourceTiming.transferSize` getter and should have been included in the last PR.